### PR TITLE
fix stale refs when accessing internal NSView

### DIFF
--- a/src/popover.rs
+++ b/src/popover.rs
@@ -25,6 +25,11 @@ impl PopoverController {
             let _: () = msg_send![&*view, setOpaque: Bool::YES];
         }
 
+        // Replace the window's contentView with an empty placeholder view.
+        let mtm = MainThreadMarker::new().unwrap();
+        let placeholder = NSView::new(mtm);
+        ns_window.setContentView(Some(&placeholder));
+
         return view;
     }
 


### PR DESCRIPTION
Fixes #25 by creating an empty placeholder NSView. Probably there may be better ways to fix.

Tested on my [app](https://github.com/xikxp1/claude-monitor) that panicked after waking laptop up before.